### PR TITLE
feat: add auth flow and dashboard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.1",
       "dependencies": {
         "axios": "^1.6.8",
+        "chart.js": "^4.4.0",
         "pinia": "^2.1.7",
         "vue": "^3.4.21",
+        "vue-chartjs": "^5.2.0",
         "vue-router": "^4.2.5",
         "vuetify": "^3.5.3"
       },
@@ -441,6 +443,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -969,6 +977,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/combined-stream": {
@@ -1653,6 +1673,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.2.tgz",
+      "integrity": "sha512-NrkbRRoYshbXbWqJkTN6InoDVwVb90C0R7eAVgMWcB9dPikbruaOoTFjFYHE/+tNPdIe6qdLCDjfjPHQ0fw4jw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
       }
     },
     "node_modules/vue-demi": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,9 @@
   "dependencies": {
     "axios": "^1.6.8",
     "pinia": "^2.1.7",
+    "chart.js": "^4.4.0",
     "vue": "^3.4.21",
+    "vue-chartjs": "^5.2.0",
     "vue-router": "^4.2.5",
     "vuetify": "^3.5.3"
   },

--- a/frontend/src/components/DashboardChart.vue
+++ b/frontend/src/components/DashboardChart.vue
@@ -1,0 +1,44 @@
+<template>
+  <v-card>
+    <v-card-title>Reportes por Mes</v-card-title>
+    <v-card-text>
+      <Bar :data="chartData" :options="chartOptions" />
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+import { Bar } from 'vue-chartjs';
+import {
+  Chart,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend
+} from 'chart.js';
+
+Chart.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+const chartData = {
+  labels: ['Enero', 'Febrero', 'Marzo'],
+  datasets: [
+    {
+      label: 'Reportes',
+      backgroundColor: '#1976D2',
+      data: [5, 10, 3]
+    }
+  ]
+};
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false
+};
+</script>
+
+<style scoped>
+.v-card-text {
+  height: 300px;
+}
+</style>

--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -8,17 +8,20 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
+import { useRouter } from 'vue-router';
 import api from '../services/api';
 import { useAuthStore } from '../store';
 
 const email = ref('');
 const password = ref('');
 const store = useAuthStore();
+const router = useRouter();
 
 async function handleLogin() {
   try {
     const { data } = await api.post('/auth/login', { email: email.value, password: password.value });
     store.setToken(data.accessToken);
+    router.push({ name: 'dashboard' });
   } catch (e) {
     console.error(e);
   }

--- a/frontend/src/components/RegisterForm.vue
+++ b/frontend/src/components/RegisterForm.vue
@@ -1,0 +1,37 @@
+<template>
+  <v-form @submit.prevent="handleRegister">
+    <v-text-field v-model="name" label="Nombre" required />
+    <v-text-field v-model="email" label="Email" type="email" required />
+    <v-text-field v-model="password" label="Contraseña" type="password" required />
+    <v-text-field v-model="confirmPassword" label="Repetir Contraseña" type="password" :rules="[matchPassword]" required />
+    <v-btn type="submit" color="primary">Registrarse</v-btn>
+  </v-form>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import api from '../services/api';
+import { useAuthStore } from '../store';
+
+const name = ref('');
+const email = ref('');
+const password = ref('');
+const confirmPassword = ref('');
+const store = useAuthStore();
+const router = useRouter();
+
+const matchPassword = (value: string) => value === password.value || 'Las contraseñas no coinciden';
+
+async function handleRegister() {
+  if (password.value !== confirmPassword.value) return;
+  try {
+    await api.post('/auth/register', { name: name.value, email: email.value, password: password.value });
+    const { data } = await api.post('/auth/login', { email: email.value, password: password.value });
+    store.setToken(data.accessToken);
+    router.push({ name: 'dashboard' });
+  } catch (e) {
+    console.error(e);
+  }
+}
+</script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,17 +1,31 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
-import HomeView from '../views/HomeView.vue';
 import LoginView from '../views/LoginView.vue';
+import RegisterView from '../views/RegisterView.vue';
 import DashboardView from '../views/DashboardView.vue';
+import { useAuthStore } from '../store';
 
 const routes: RouteRecordRaw[] = [
-  { path: '/', name: 'home', component: HomeView },
+  { path: '/', redirect: '/dashboard' },
   { path: '/login', name: 'login', component: LoginView },
-  { path: '/dashboard', name: 'dashboard', component: DashboardView }
+  { path: '/register', name: 'register', component: RegisterView },
+  { path: '/dashboard', name: 'dashboard', component: DashboardView, meta: { requiresAuth: true } }
 ];
 
 const router = createRouter({
   history: createWebHistory(),
   routes
+});
+
+router.beforeEach((to, from, next) => {
+  const store = useAuthStore();
+  const hasToken = store.token;
+  if (!hasToken && to.name !== 'login' && to.name !== 'register') {
+    next({ name: 'login' });
+  } else if (hasToken && (to.name === 'login' || to.name === 'register')) {
+    next({ name: 'dashboard' });
+  } else {
+    next();
+  }
 });
 
 export default router;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -4,4 +4,13 @@ const api = axios.create({
   baseURL: 'http://localhost:3000'
 });
 
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 export default api;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,10 +1,17 @@
 import { defineStore } from 'pinia';
 
 export const useAuthStore = defineStore('auth', {
-  state: () => ({ token: '' }),
+  state: () => ({
+    token: localStorage.getItem('token') || ''
+  }),
   actions: {
     setToken(token: string) {
       this.token = token;
+      localStorage.setItem('token', token);
+    },
+    clearToken() {
+      this.token = '';
+      localStorage.removeItem('token');
     }
   }
 });

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,5 +1,49 @@
 <template>
-  <div>Dashboard</div>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-card>
+          <v-card-title>Estadísticas</v-card-title>
+          <v-card-text>
+            <div>Reportes ciudadanos: 42</div>
+            <div>Usuarios activos: 10</div>
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col cols="12" md="4">
+        <v-card>
+          <v-card-title>Últimas actividades</v-card-title>
+          <v-card-text>
+            <v-list density="compact">
+              <v-list-item v-for="(activity, i) in activities" :key="i">
+                <v-list-item-title>{{ activity }}</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col cols="12" md="4">
+        <v-card>
+          <v-card-title>Perfil</v-card-title>
+          <v-card-text>
+            <div>Nombre: {{ user.name }}</div>
+            <div>Email: {{ user.email }}</div>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        <DashboardChart />
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref } from 'vue';
+import DashboardChart from '../components/DashboardChart.vue';
+
+const activities = ref(['Reporte A', 'Reporte B', 'Reporte C']);
+const user = ref({ name: 'John Doe', email: 'john@example.com' });
+</script>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,5 +1,0 @@
-<template>
-  <div>Home</div>
-</template>
-
-<script setup lang="ts"></script>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,5 +1,8 @@
 <template>
-  <LoginForm />
+  <div>
+    <LoginForm />
+    <router-link to="/register">¿No tienes cuenta? Regístrate</router-link>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <RegisterForm />
+    <router-link to="/login">¿Ya tienes cuenta? Inicia sesión</router-link>
+  </div>
+</template>
+
+<script setup lang="ts">
+import RegisterForm from '../components/RegisterForm.vue';
+</script>


### PR DESCRIPTION
## Summary
- add login and registration views connected to auth endpoints
- secure routes with Pinia-based JWT store and router guards
- scaffold dashboard with stats cards and chart component

## Testing
- `npm run build`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c4e99f03f08330a1d4e10217dd51a4