### PR TITLE
Implement auth endpoints with roles and seed data

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,16 +10,19 @@
       "dependencies": {
         "@prisma/client": "^5.10.2",
         "bcrypt": "^5.1.0",
+        "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.0",
+        "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.4",
         "@types/node": "^20.11.30",
         "prisma": "^5.10.2",
+        "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.2"
       }
@@ -206,6 +209,16 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -688,6 +701,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,22 +3,26 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.10.2",
     "bcrypt": "^5.1.0",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.4",
+    "@types/cors": "^2.8.17",
     "@types/node": "^20.11.30",
     "prisma": "^5.10.2",
     "ts-node-dev": "^2.0.0",
+    "ts-node": "^10.9.1",
     "typescript": "^5.4.2"
   }
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -7,9 +7,16 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Role {
+  admin
+  mayor
+  citizen
+}
+
 model User {
   id       Int    @id @default(autoincrement())
   name     String
   email    String @unique
   password String
+  role     Role   @default(citizen)
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,25 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcrypt';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const password = await bcrypt.hash('123456', 10);
+  await prisma.user.upsert({
+    where: { email: 'admin@demo.com' },
+    update: {},
+    create: {
+      name: 'Admin',
+      email: 'admin@demo.com',
+      password,
+      role: 'admin'
+    }
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -1,10 +1,8 @@
 import { Request, Response } from 'express';
-import * as userService from '../services/userService';
 
 export async function getMe(req: Request, res: Response) {
   try {
-    const userId = (req as any).userId as number;
-    const user = await userService.getUserById(userId);
+    const user = (req as any).user;
     res.json(user);
   } catch (err: any) {
     res.status(400).json({ message: err.message });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,11 +1,13 @@
 import express from 'express';
 import dotenv from 'dotenv';
+import cors from 'cors';
 import authRoutes from './routes/auth';
 import userRoutes from './routes/user';
 
 dotenv.config();
 
 const app = express();
+app.use(cors({ origin: process.env.FRONTEND_URL || '*', credentials: true }));
 app.use(express.json());
 
 app.use('/auth', authRoutes);

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -1,15 +1,18 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import * as userService from '../services/userService';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
-export function verifyToken(req: Request, res: Response, next: NextFunction) {
+export async function verifyToken(req: Request, res: Response, next: NextFunction) {
   const auth = req.headers.authorization;
   if (!auth) return res.status(401).json({ message: 'No token provided' });
   const [, token] = auth.split(' ');
   try {
     const payload = jwt.verify(token, JWT_SECRET) as any;
-    (req as any).userId = payload.userId;
+    const user = await userService.getUserById(payload.userId);
+    if (!user) return res.status(401).json({ message: 'Invalid token' });
+    (req as any).user = user;
     next();
   } catch {
     return res.status(401).json({ message: 'Invalid token' });

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,16 +1,22 @@
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import { Role } from '@prisma/client';
 import { prisma } from '../prisma/client';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 const JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'refreshsecret';
 
-type RegisterInput = { name: string; email: string; password: string };
+type RegisterInput = { name: string; email: string; password: string; role?: Role };
 type LoginInput = { email: string; password: string };
 
-export async function register({ name, email, password }: RegisterInput) {
+export async function register({ name, email, password, role }: RegisterInput) {
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) throw new Error('Email already registered');
   const hashed = await bcrypt.hash(password, 10);
-  return prisma.user.create({ data: { name, email, password: hashed } });
+  return prisma.user.create({
+    data: { name, email, password: hashed, role: role || 'citizen' },
+    select: { id: true, name: true, email: true, role: true }
+  });
 }
 
 export async function login({ email, password }: LoginInput) {

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -3,6 +3,6 @@ import { prisma } from '../prisma/client';
 export function getUserById(id: number) {
   return prisma.user.findUnique({
     where: { id },
-    select: { id: true, name: true, email: true }
+    select: { id: true, name: true, email: true, role: true }
   });
 }


### PR DESCRIPTION
## Summary
- add user role enum and default role in Prisma schema
- handle registration with unique email validation and role assignment
- secure routes with JWT middleware attaching user to requests
- enable CORS and add seed script for admin user

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run seed` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68c4eb2580c88330909da75eca0a6e3e